### PR TITLE
fix: restrict Amex CVC length to 4 digits

### DIFF
--- a/sdk-utils/validation/CardPattern.res
+++ b/sdk-utils/validation/CardPattern.res
@@ -79,7 +79,7 @@ let cardPatterns = [
   {
     issuer: "AmericanExpress",
     pattern: %re("/^3[47]/"),
-    cvcLength: [3, 4],
+    cvcLength: [4],
     length: [14, 15],
     maxCVCLength: 4,
     pincodeRequired: true,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD

## Description

In our codebase, we were incorrectly allowing Amex CVC to be 3–4 digits. This has now been corrected to allow exactly 4 digits, as per the specification.
https://juspay.slack.com/archives/C03V08QDR24/p1753087923381849

## How did you test it?
I have tested it in local setup.
<!--
Describe how you tested your changes:

- Did you write integration/unit/API tests?
- Did you verify compatibility with both the mobile and web repositories (provide steps)?
- Attach relevant logs or screenshots, if applicable.
-->

## Impact on Mobile and Web Repositories

Outline steps taken to ensure compatibility with consuming repositories:

- [ ] I tested the submodule changes in the **mobile repository**.
- [x] I tested the submodule changes in the **web repository**.
- [ ] I updated the corresponding documentation in both repositories, if applicable.
- [ ] I confirmed the changes do not introduce regressions in either repository.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code thoroughly.
- [x] I ensured the changes are compatible with **both mobile and web repositories**.
- [ ] I communicated potential breaking changes, if any, to the relevant teams.
