### PR TITLE
feat(superposition): integrate /sdk-configs endpoint for dynamic field rendering

### DIFF
--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -11,33 +11,53 @@ external cacReader: JSON.t => Nullable.t<configurationService> = "CacReader"
 let service = ref(None)
 
 let useConfigurationService = () => {
-  React.useEffect0(() => {
-    let initializeService = async () => {
-      if service.contents->Option.isNone {
-        try {
-          let s3Path = "assets/v2/configs/superposition.config.json"
-          let configData = try {
-            let response = await Fetch.fetch(
-              `https://checkout.hyperswitch.io/${s3Path}`,
-              {
-                method: #GET,
-              }
-            )
-            await response->Fetch.Response.json
-          } catch {
-          | _ => await importJSON(`./../../${s3Path}`)
-          }
+  let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
 
-          let configService = cacReader(configData)->Nullable.toOption
-          service := configService
+  React.useEffect1(() => {
+    let loadFallbackService = async () => {
+      try {
+        let s3Path = "assets/v2/configs/superposition.config.json"
+        let configData = await importJSON(`./../../${s3Path}`)
+        cacReader(configData)->Nullable.toOption
+      } catch {
+      | _ex => None
+      }
+    }
+
+    let initializeService = async () => {
+      switch nativeProp.superpositionConfig.configJson {
+      | Some(nativeConfig) =>
+        let nativeService = try {
+          cacReader(nativeConfig)->Nullable.toOption
         } catch {
-        | _ex => service := None
+        | _ex => None
+        }
+        switch nativeService {
+        | Some(_) => service := nativeService
+        | None =>
+          let fallbackService = await loadFallbackService()
+          switch fallbackService {
+          | Some(_) => service := fallbackService
+          | None =>
+            if service.contents->Option.isNone {
+              service := None
+            }
+          }
+        }
+      | None =>
+        let fallbackService = await loadFallbackService()
+        switch fallbackService {
+        | Some(_) => service := fallbackService
+        | None =>
+          if service.contents->Option.isNone {
+            service := None
+          }
         }
       }
     }
     initializeService()->ignore
     None
-  })
+  }, [nativeProp.superpositionConfig.configJson])
 
   (
     eligibleConnectors: array<RescriptCore.JSON.t>,

--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -8,6 +8,17 @@ external importJSON: string => promise<JSON.t> = "import"
 @module("./../superposition/superposition.js") @new
 external cacReader: JSON.t => Nullable.t<configurationService> = "CacReader"
 
+let extractRawConfigs = (config: JSON.t): JSON.t => {
+  switch config->JSON.Decode.object {
+  | Some(dict) =>
+    switch dict->Dict.get("raw_configs")->Option.flatMap(JSON.Decode.object) {
+    | Some(rawConfigs) => rawConfigs->JSON.Encode.object
+    | None => config
+    }
+  | None => config
+  }
+}
+
 let service = ref(None)
 
 let useConfigurationService = () => {
@@ -18,7 +29,7 @@ let useConfigurationService = () => {
       try {
         let s3Path = "assets/v2/configs/superposition.config.json"
         let configData = await importJSON(`./../../${s3Path}`)
-        cacReader(configData)->Nullable.toOption
+        cacReader(extractRawConfigs(configData))->Nullable.toOption
       } catch {
       | _ex => None
       }
@@ -28,7 +39,7 @@ let useConfigurationService = () => {
       switch nativeProp.hyperParams.superpositionConfigRaw {
       | Some(nativeConfig) =>
         let nativeService = try {
-          cacReader(nativeConfig)->Nullable.toOption
+          cacReader(extractRawConfigs(nativeConfig))->Nullable.toOption
         } catch {
         | _ex => None
         }

--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -19,7 +19,25 @@ let extractRawConfigs = (config: JSON.t): JSON.t => {
   }
 }
 
-let service = ref(None)
+let extractContextUsed = (config: JSON.t): (string, string, string) => {
+  switch config->JSON.Decode.object {
+  | Some(dict) =>
+    switch dict->Dict.get("context_used")->Option.flatMap(JSON.Decode.object) {
+    | Some(contextDict) => (
+        contextDict->Dict.get("profile_id")->Option.flatMap(JSON.Decode.string)->Option.getOr(""),
+        contextDict->Dict.get("merchant_id")->Option.flatMap(JSON.Decode.string)->Option.getOr(""),
+        contextDict
+        ->Dict.get("organization_id")
+        ->Option.flatMap(JSON.Decode.string)
+        ->Option.getOr(""),
+      )
+    | None => ("", "", "")
+    }
+  | None => ("", "", "")
+  }
+}
+
+let service: ref<option<(configurationService, string, string, string)>> = ref(None)
 
 let useConfigurationService = () => {
   let (nativeProp, _) = React.useContext(NativePropContext.nativePropContext)
@@ -29,7 +47,10 @@ let useConfigurationService = () => {
       try {
         let s3Path = "assets/v2/configs/superposition.config.json"
         let configData = await importJSON(`./../../${s3Path}`)
-        cacReader(extractRawConfigs(configData))->Nullable.toOption
+        let (profileId, merchantId, organizationId) = extractContextUsed(configData)
+        cacReader(extractRawConfigs(configData))
+        ->Nullable.toOption
+        ->Option.map(svc => (svc, profileId, merchantId, organizationId))
       } catch {
       | _ex => None
       }
@@ -39,7 +60,10 @@ let useConfigurationService = () => {
       switch nativeProp.hyperParams.superpositionConfigRaw {
       | Some(nativeConfig) =>
         let nativeService = try {
-          cacReader(extractRawConfigs(nativeConfig))->Nullable.toOption
+          let (profileId, merchantId, organizationId) = extractContextUsed(nativeConfig)
+          cacReader(extractRawConfigs(nativeConfig))
+          ->Nullable.toOption
+          ->Option.map(svc => (svc, profileId, merchantId, organizationId))
         } catch {
         | _ex => None
         }
@@ -81,7 +105,7 @@ let useConfigurationService = () => {
     ) {
     | (_, true)
     | (None, false) => []
-    | (Some(svc), false) =>
+    | (Some((svc, profileId, merchantId, organizationId)), false) =>
       eligibleConnectors
       ->removeDuplicateConnectors
       ->Array.reduce([], (acc, connector) => {
@@ -97,6 +121,9 @@ let useConfigurationService = () => {
               mandate_type: configParams.mandate_type,
               collect_billing_details_from_wallet_connector: configParams.collect_billing_details_from_wallet_connector,
               collect_shipping_details_from_wallet_connector: configParams.collect_shipping_details_from_wallet_connector,
+              profile_id: profileId,
+              merchant_id: merchantId,
+              organization_id: organizationId,
             }
             let resolvedConfig =
               svc.evaluateConfig(transformedContext)->convertConfigurationToRequiredFields

--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -25,7 +25,7 @@ let useConfigurationService = () => {
     }
 
     let initializeService = async () => {
-      switch nativeProp.superpositionConfig.configJson {
+      switch nativeProp.hyperParams.superpositionConfigRaw {
       | Some(nativeConfig) =>
         let nativeService = try {
           cacReader(nativeConfig)->Nullable.toOption
@@ -57,7 +57,7 @@ let useConfigurationService = () => {
     }
     initializeService()->ignore
     None
-  }, [nativeProp.superpositionConfig.configJson])
+  }, [nativeProp.hyperParams.superpositionConfigRaw])
 
   (
     eligibleConnectors: array<RescriptCore.JSON.t>,

--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -114,7 +114,7 @@ let useConfigurationService = () => {
           | Some("") | None => ()
           | Some(connector) =>
             let transformedContext: SuperpositionTypes.superpositionContext = {
-              connector: connector->CommonUtils.snakeToPascalCase,
+              connector,
               payment_method: configParams.payment_method->CommonUtils.snakeToPascalCase,
               payment_method_type: configParams.payment_method_type->CommonUtils.snakeToPascalCase,
               country: configParams.country,

--- a/sdk-utils/types/SuperpositionTypes.res
+++ b/sdk-utils/types/SuperpositionTypes.res
@@ -38,6 +38,9 @@ type superpositionBaseContext = {
 type superpositionContext = {
   ...superpositionBaseContext,
   connector: string,
+  profile_id: string,
+  merchant_id: string,
+  organization_id: string,
 }
 
 let stringToFieldType = str => {

--- a/sdk-utils/utils/SuperpositionHelper.res
+++ b/sdk-utils/utils/SuperpositionHelper.res
@@ -188,7 +188,13 @@ let convertConfigurationToRequiredFields = resolvedConfig => {
   resolvedConfig
   ->Dict.toArray
   ->Array.forEach(((key, value)) => {
-    let parts = key->String.split("._")
+    let dynamicFieldsprefix = "dynamic_fields."
+    let normalizedKey = if key->String.startsWith(dynamicFieldsprefix) {
+      key->String.sliceToEnd(~start=dynamicFieldsprefix->String.length)
+    } else {
+      key
+    }
+    let parts = normalizedKey->String.split("._")
     switch (parts->Array.get(0), parts->Array.get(1)) {
     | (Some(baseName), Some(metadataKey)) if baseName !== "" && metadataKey !== "" => {
         let fieldGroup = switch fieldGroups->Dict.get(baseName) {


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD

## Description

- ConfigurationService now reads nativeProp.hyperParams.superpositionConfigRaw first, with S3-bundled config/static file as fallback.
- Adds extractRawConfigs / extractContextUsed to parse the response shape.
- SuperpositionTypes.superpositionContext extended with profile_id, merchant_id, organization_id.
- SuperpositionHelper strips the dynamic_fields. key prefix returned by BE.

<!-- Describe your changes in detail -->

## How did you test it?

<!--
Describe how you tested your changes:

- Did you write integration/unit/API tests?
- Did you verify compatibility with both the mobile and web repositories (provide steps)?
- Attach relevant logs or screenshots, if applicable.
-->

## Impact on Mobile and Web Repositories

Outline steps taken to ensure compatibility with consuming repositories:

- [x] I tested the submodule changes in the **mobile repository**.
- [ ] I tested the submodule changes in the **web repository**.
- [ ] I updated the corresponding documentation in both repositories, if applicable.
- [ ] I confirmed the changes do not introduce regressions in either repository.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code thoroughly.
- [ ] I ensured the changes are compatible with **both mobile and web repositories**.
- [ ] I communicated potential breaking changes, if any, to the relevant teams.
