### PR TITLE
feat: added parsing for account config

### DIFF
--- a/sdk-utils/types/SdkConfigTypes.res
+++ b/sdk-utils/types/SdkConfigTypes.res
@@ -1,3 +1,5 @@
+type vaultingAction = Skip | Tokenize
+
 type criteriaRule = {
   criteria_value: string,
   eligible_connectors: array<string>,
@@ -14,12 +16,18 @@ type sdkPaymentMethod = {
   payment_method_types: array<sdkPaymentMethodType>,
 }
 
+type profile = {vaulting_action: vaultingAction}
+
+type accountConfig = {profile: option<profile>}
+
 type sdkConfigValue = {
   raw_configs: option<JSON.t>,
   payment_methods: array<sdkPaymentMethod>,
+  account_config: option<accountConfig>,
 }
 
 let defaultSdkConfigValue: sdkConfigValue = {
   raw_configs: None,
   payment_methods: [],
+  account_config: None,
 }

--- a/sdk-utils/utils/SdkConfigParser.res
+++ b/sdk-utils/utils/SdkConfigParser.res
@@ -28,11 +28,37 @@ let parseSdkPaymentMethod = (json: JSON.t): sdkPaymentMethod => {
   }
 }
 
+let getVaultingActionFromName = (name: string): vaultingAction => {
+  switch name {
+  | "tokenize" => Tokenize
+  | _ => Skip
+  }
+}
+
+let parseProfile = (json: JSON.t): profile => {
+  let dict = json->getDictFromJson
+  {
+    vaulting_action: dict
+    ->getString("vaulting_action", "")
+    ->getVaultingActionFromName,
+  }
+}
+
+let parseProfileAccountConfig = (json: JSON.t): accountConfig => {
+  let dict = json->getDictFromJson
+  {
+    profile: dict->Dict.get("profile")->Option.map(parseProfile),
+  }
+}
+
 let itemToObjMapper = (json: JSON.t): sdkConfigValue => {
   let dict = json->getDictFromJson
   {
     raw_configs: dict->Dict.get("raw_configs"),
     payment_methods: dict->getArray("payment_methods")->Array.map(parseSdkPaymentMethod),
+    account_config: dict
+    ->Dict.get("account_config")
+    ->Option.map(parseProfileAccountConfig),
   }
 }
 


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
Added parsing for account config for sdk configs API
Sample Response
```
{
    "raw_configs": {..},
    "resolved_configs": null,
    "context_used": {
        "profile_id": "pro_eZyKe4CGg830Gnj3RXIl",
        "merchant_id": "merchant_1781610434",
        "organization_id": "org_cPgw4fcv4pQj9E2fIISM",
        "connector": [
            "stripe"
        ]
    },
    "payment_methods": [..],
    "account_config": {
        "profile": {
            "collect_shipping_details_from_wallet_connector": false,
            "collect_billing_details_from_wallet_connector": false,
            "always_collect_billing_details_from_wallet_connector": false,
            "always_collect_shipping_details_from_wallet_connector": false,
            "vaulting_action": "skip"
        }
    }
}
```

## How did you test it?

<!--
Describe how you tested your changes:

- Did you write integration/unit/API tests?
- Did you verify compatibility with both the mobile and web repositories (provide steps)?
- Attach relevant logs or screenshots, if applicable.
-->

## Impact on Mobile and Web Repositories

Outline steps taken to ensure compatibility with consuming repositories:

- [ ] I tested the submodule changes in the **mobile repository**.
- [X] I tested the submodule changes in the **web repository**.
- [X] I updated the corresponding documentation in both repositories, if applicable.
- [X] I confirmed the changes do not introduce regressions in either repository.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I reviewed submitted code thoroughly.
- [X] I ensured the changes are compatible with **both mobile and web repositories**.
- [X] I communicated potential breaking changes, if any, to the relevant teams.
