### PR TITLE
fix: initial values for sp new

### DIFF
--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -19,7 +19,7 @@ let useConfigurationService = (~rawConfigs: option<JSON.t>) => {
     (
       eligibleConnectors: array<RescriptCore.JSON.t>,
       configParams: SuperpositionTypes.superpositionBaseContext,
-      requiredFieldsFromPML,
+      flatIntentData,
     ) => {
       let requiredFieldsFromSuperPosition = switch (
         service,
@@ -59,10 +59,12 @@ let useConfigurationService = (~rawConfigs: option<JSON.t>) => {
 
       let missingRequiredFields = filterFieldsBasedOnMissingData(
         requiredFieldsFromSuperPosition,
-        requiredFieldsFromPML,
+        flatIntentData,
       )
 
-      let initialValues = convertFlatDictToNestedObject(requiredFieldsFromPML)
+      let initialValues =
+        buildInitialValuesFromIntentData(requiredFieldsFromSuperPosition, flatIntentData)
+        ->convertFlatDictToNestedObject
 
       (requiredFieldsFromSuperPosition, missingRequiredFields, initialValues)
     },

--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -19,8 +19,9 @@ let useConfigurationService = (~rawConfigs: option<JSON.t>) => {
     (
       eligibleConnectors: array<RescriptCore.JSON.t>,
       configParams: SuperpositionTypes.superpositionBaseContext,
-      flatIntentData,
+      intentData: JSON.t,
     ) => {
+      let intentDataDict = intentData->CommonUtils.getDictFromJson
       let requiredFieldsFromSuperPosition = switch (
         service,
         Array.length(eligibleConnectors) === 0,
@@ -59,12 +60,14 @@ let useConfigurationService = (~rawConfigs: option<JSON.t>) => {
 
       let missingRequiredFields = filterFieldsBasedOnMissingData(
         requiredFieldsFromSuperPosition,
-        flatIntentData,
+        intentDataDict,
       )
 
       let initialValues =
-        buildInitialValuesFromIntentData(requiredFieldsFromSuperPosition, flatIntentData)
-        ->convertFlatDictToNestedObject
+        buildInitialValuesFromIntentData(
+          requiredFieldsFromSuperPosition,
+          intentDataDict,
+        )->convertFlatDictToNestedObject
 
       (requiredFieldsFromSuperPosition, missingRequiredFields, initialValues)
     },

--- a/sdk-utils/utils/CommonUtils.res
+++ b/sdk-utils/utils/CommonUtils.res
@@ -97,6 +97,27 @@ let getDictFromDict = (dict, key) => {
   dict->getJsonObjectFromDict(key)->getDictFromJson
 }
 
+// Read the value at a dot-separated object path.
+let rec getValueAtNestedPath = (dict: Dict.t<JSON.t>, keys: array<string>): option<JSON.t> =>
+  switch keys {
+  | [] => None
+  | [key] => dict->Dict.get(key)
+  | _ =>
+    switch keys
+    ->Array.get(0)
+    ->Option.flatMap(key => dict->Dict.get(key))
+    ->Option.flatMap(JSON.Decode.object) {
+    | Some(innerDict) => getValueAtNestedPath(innerDict, keys->Array.sliceToEnd(~start=1))
+    | None => None
+    }
+  }
+
+let getNestedValue = (dict: Dict.t<JSON.t>, path: string): option<JSON.t> =>
+  getValueAtNestedPath(dict, path->String.split("."))
+
+let getStringAtPath = (dict: Dict.t<JSON.t>, path: string): option<string> =>
+  getNestedValue(dict, path)->Option.flatMap(JSON.Decode.string)
+
 let getBool = (dict, key, default) => {
   getOptionBool(dict, key)->Option.getOr(default)
 }

--- a/sdk-utils/utils/SuperpositionHelper.res
+++ b/sdk-utils/utils/SuperpositionHelper.res
@@ -59,17 +59,21 @@ let extractFieldValuesFromPML = (required_fields: Dict.t<JSON.t>) => {
 
 let filterFieldsBasedOnMissingData = (
   requiredFieldsFromSuperPosition: SuperpositionTypes.requiredFields,
-  requiredFieldsFromPML,
+  flatIntentData,
 ) => {
   let firstNamePattern = "billing.address.first_name"
   let lastNamePattern = "billing.address.last_name"
   let phonePattern = "billing.phone"
   let addressPattern = "billing.address."
 
-  let isFieldMissing = path => {
-    switch requiredFieldsFromPML->Dict.get(path) {
-    | Some("") | None => true
-    | _ => false
+  let isFieldMissing = field => {
+    switch field.intentDataReadPath {
+    | None => true
+    | Some(readPath) =>
+      switch flatIntentData->Dict.get(readPath) {
+      | Some(val) when val !== "" => false
+      | _ => true
+      }
     }
   }
 
@@ -83,7 +87,7 @@ let filterFieldsBasedOnMissingData = (
     field,
   ) => {
     let path = field.confirmRequestWritePath
-    let fieldMissing = isFieldMissing(path)
+    let fieldMissing = isFieldMissing(field)
 
     let isNameField =
       path->String.includes(firstNamePattern) || path->String.includes(lastNamePattern)
@@ -101,15 +105,28 @@ let filterFieldsBasedOnMissingData = (
   })
 
   fieldCategories->Array.filterMap(((field, isNameField, isPhoneField, isAddressField)) => {
-    let path = field.confirmRequestWritePath
-
     let shouldInclude =
       (isNameField && nameFieldsMissing) ||
       isPhoneField && phoneFieldsMissing ||
       isAddressField && addressFieldsMissing ||
-      (!isNameField && !isPhoneField && !isAddressField && isFieldMissing(path))
+      (!isNameField && !isPhoneField && !isAddressField && isFieldMissing(field))
 
     shouldInclude ? Some(field) : None
+  })
+}
+
+let buildInitialValuesFromIntentData = (
+  fields: SuperpositionTypes.requiredFields,
+  flatIntentData: Dict.t<string>,
+): Dict.t<string> => {
+  fields->Array.reduce(Dict.make(), (acc, field) => {
+    field.intentDataReadPath->Option.forEach(readPath => {
+      switch flatIntentData->Dict.get(readPath) {
+      | Some(val) when val !== "" => acc->Dict.set(field.confirmRequestWritePath, val)
+      | _ => ()
+      }
+    })
+    acc
   })
 }
 

--- a/sdk-utils/utils/SuperpositionHelper.res
+++ b/sdk-utils/utils/SuperpositionHelper.res
@@ -57,25 +57,26 @@ let extractFieldValuesFromPML = (required_fields: Dict.t<JSON.t>) => {
   flatInitialValues
 }
 
+let resolveFieldValue = (field, intentDataDict) =>
+  switch field.intentDataReadPath {
+  | Some(readPath) =>
+    switch getStringAtPath(intentDataDict, readPath) {
+    | Some(val) if val !== "" => Some(val)
+    | _ => None
+    }
+  | None => None
+  }
+
 let filterFieldsBasedOnMissingData = (
   requiredFieldsFromSuperPosition: SuperpositionTypes.requiredFields,
-  flatIntentData,
+  intentDataDict,
 ) => {
   let firstNamePattern = "billing.address.first_name"
   let lastNamePattern = "billing.address.last_name"
   let phonePattern = "billing.phone"
   let addressPattern = "billing.address."
 
-  let isFieldMissing = field => {
-    switch field.intentDataReadPath {
-    | None => true
-    | Some(readPath) =>
-      switch flatIntentData->Dict.get(readPath) {
-      | Some(val) when val !== "" => false
-      | _ => true
-      }
-    }
-  }
+  let isFieldMissing = field => resolveFieldValue(field, intentDataDict)->Option.isNone
 
   let (
     fieldCategories,
@@ -117,15 +118,13 @@ let filterFieldsBasedOnMissingData = (
 
 let buildInitialValuesFromIntentData = (
   fields: SuperpositionTypes.requiredFields,
-  flatIntentData: Dict.t<string>,
+  intentDataDict: Dict.t<JSON.t>,
 ): Dict.t<string> => {
   fields->Array.reduce(Dict.make(), (acc, field) => {
-    field.intentDataReadPath->Option.forEach(readPath => {
-      switch flatIntentData->Dict.get(readPath) {
-      | Some(val) when val !== "" => acc->Dict.set(field.confirmRequestWritePath, val)
-      | _ => ()
-      }
-    })
+    switch resolveFieldValue(field, intentDataDict) {
+    | Some(val) => acc->Dict.set(field.confirmRequestWritePath, val)
+    | None => ()
+    }
     acc
   })
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD

## Description

Fix initialValue collection from intent data object

## How did you test it?

For intent-data object:
```
{
    "payment_id": "pay_GkG3HvVNVCEpW2xRhvGY",
    "status": "requires_payment_method",
    "amount": 2999,
    "currency": "USD",
    "client_secret": "pay_GkG3HvVNVCEpW2xRhvGY_secret_8QoCq94ZErZidCTlTyrG",
    "description": "Hello this is description",
    "customer_id": "hyperswitch_sdk_demo_id",
    "return_url": null,
    "setup_future_usage": null,
    "billing": {
        "address": {
            "city": "San Fransico",
            "country": null,
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "shipping": {
        "address": {
            "city": "San Fransico",
            "country": "US",
            "line1": "1467",
            "line2": "Harrison Street",
            "line3": "Harrison Street",
            "zip": "94122",
            "state": "California",
            "first_name": "joseph",
            "last_name": "Doe",
            "origin_zip": null
        },
        "phone": {
            "number": "8056594427",
            "country_code": "+91"
        },
        "email": null
    },
    "metadata": {
        "udf1": "value1",
        "login_date": "2019-09-10T10:11:12Z",
        "new_customer": "true"
    },
    "order_details": [
        {
            "sku": null,
            "upc": null,
            "brand": null,
            "amount": 2999,
            "category": null,
            "quantity": 1,
            "tax_rate": null,
            "product_id": null,
            "description": null,
            "product_name": "Apple iPhone 15",
            "product_type": null,
            "sub_category": null,
            "total_amount": null,
            "commodity_code": null,
            "unit_of_measure": null,
            "product_img_link": null,
            "product_tax_code": null,
            "total_tax_amount": null,
            "requires_shipping": null,
            "unit_discount_amount": null
        }
    ],
    "created": "2026-06-17 16:04:56.599371",
    "expires_on": "2026-06-17 16:07:56.599366",
    "profile_id": "pro_7Jn2p2ZZAwlsjd2ZRd59",
    "merchant_order_reference_id": null,
    "attempt_count": 1,
    "installment_options": null,
    "capture_method": "automatic",
    "merchant_name": "Juspay",
    "mandate_payment": null,
    "payment_type": "normal",
    "request_external_three_ds_authentication": false,
    "is_tax_calculation_enabled": true,
    "is_guest_customer": false
}
```

UI rendered:
<img width="562" height="795" alt="image" src="https://github.com/user-attachments/assets/3f2f2ab1-5841-498a-9e4c-644aa79f9a1c" />


<!--
Describe how you tested your changes:

- Did you write integration/unit/API tests?
- Did you verify compatibility with both the mobile and web repositories (provide steps)?
- Attach relevant logs or screenshots, if applicable.
-->

## Impact on Mobile and Web Repositories

Outline steps taken to ensure compatibility with consuming repositories:

- [ ] I tested the submodule changes in the **mobile repository**.
- [ ] I tested the submodule changes in the **web repository**.
- [ ] I updated the corresponding documentation in both repositories, if applicable.
- [ ] I confirmed the changes do not introduce regressions in either repository.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I reviewed submitted code thoroughly.
- [ ] I ensured the changes are compatible with **both mobile and web repositories**.
- [ ] I communicated potential breaking changes, if any, to the relevant teams.
