### PR TITLE
fix: default placeholder text in superposition fieldConfig

### DIFF
--- a/sdk-utils/types/SuperpositionTypes.res
+++ b/sdk-utils/types/SuperpositionTypes.res
@@ -24,6 +24,7 @@ type fieldType =
 type rec fieldConfig = {
   intentDataReadPath: option<string>,
   defaultLabelText: string,
+  defaultPlaceholderText: string,
   fieldRenderType: fieldType,
   fieldDisplayOrder: int,
   isRequired: bool,

--- a/sdk-utils/utils/SuperpositionHelper.res
+++ b/sdk-utils/utils/SuperpositionHelper.res
@@ -231,6 +231,7 @@ let convertConfigurationToRequiredFields = resolvedConfig => {
     if isRequired {
       let confirmRequestWritePath = metadata->getString("confirm_request_write_path", baseName)
       let defaultLabelText = metadata->getString("default_label_text", baseName)
+      let defaultPlaceholderText = metadata->getString("default_placeholder_text", "")
       let fieldRenderTypeStr = metadata->getString("field_render_type", "")
       let fieldDisplayOrder = metadata->getInt("field_display_order", 1000)
       let dropdownOptions =
@@ -256,6 +257,7 @@ let convertConfigurationToRequiredFields = resolvedConfig => {
       Some({
         intentDataReadPath,
         defaultLabelText,
+        defaultPlaceholderText,
         fieldRenderType: fieldRenderTypeStr->stringToFieldType,
         fieldDisplayOrder,
         isRequired,


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD

## Description

<!-- Describe your changes in detail -->
- Placeholder default value read operation was missing for superposition fieldConfigs.

## How did you test it?
- Tested by locally attaching `"raw_configs"` and checking behaviour in `hyperswitch-web` repo.

<!--
Describe how you tested your changes:

- Did you write integration/unit/API tests?
- Did you verify compatibility with both the mobile and web repositories (provide steps)?
- Attach relevant logs or screenshots, if applicable.
-->

## Impact on Mobile and Web Repositories

Outline steps taken to ensure compatibility with consuming repositories:

- [ ] I tested the submodule changes in the **mobile repository**.
- [X] I tested the submodule changes in the **web repository**.
- [ ] I updated the corresponding documentation in both repositories, if applicable.
- [ ] I confirmed the changes do not introduce regressions in either repository.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I reviewed submitted code thoroughly.
- [X] I ensured the changes are compatible with **both mobile and web repositories**.
- [ ] I communicated potential breaking changes, if any, to the relevant teams.
