### PR TITLE
feat: add OPPP as dimension for dynamicFields resolution

### DIFF
--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -44,6 +44,7 @@ let useConfigurationService = (~rawConfigs: option<JSON.t>) => {
                 mandate_type: configParams.mandate_type,
                 collect_billing_details_from_wallet_connector: configParams.collect_billing_details_from_wallet_connector,
                 collect_shipping_details_from_wallet_connector: configParams.collect_shipping_details_from_wallet_connector,
+                platform: configParams.platform,
                 profile_id: ?configParams.profile_id,
                 processor_merchant_id: ?configParams.processor_merchant_id,
                 organization_id: ?configParams.organization_id,

--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -44,6 +44,9 @@ let useConfigurationService = (~rawConfigs: option<JSON.t>) => {
                 mandate_type: configParams.mandate_type,
                 collect_billing_details_from_wallet_connector: configParams.collect_billing_details_from_wallet_connector,
                 collect_shipping_details_from_wallet_connector: configParams.collect_shipping_details_from_wallet_connector,
+                profile_id: ?configParams.profile_id,
+                merchant_id: ?configParams.merchant_id,
+                organization_id: ?configParams.organization_id,
               }
               let resolvedConfig =
                 svc.evaluateConfig(transformedContext)->convertConfigurationToRequiredFields

--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -45,7 +45,7 @@ let useConfigurationService = (~rawConfigs: option<JSON.t>) => {
                 collect_billing_details_from_wallet_connector: configParams.collect_billing_details_from_wallet_connector,
                 collect_shipping_details_from_wallet_connector: configParams.collect_shipping_details_from_wallet_connector,
                 profile_id: ?configParams.profile_id,
-                merchant_id: ?configParams.merchant_id,
+                processor_merchant_id: ?configParams.processor_merchant_id,
                 organization_id: ?configParams.organization_id,
               }
               let resolvedConfig =

--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -41,12 +41,14 @@ let useConfigurationService = (~rawConfigs: option<JSON.t>) => {
                 payment_method: configParams.payment_method->CommonUtils.snakeToPascalCase,
                 payment_method_type: configParams.payment_method_type->CommonUtils.snakeToPascalCase,
                 country: configParams.country,
+                currency: ?configParams.currency,
                 mandate_type: configParams.mandate_type,
                 collect_billing_details_from_wallet_connector: configParams.collect_billing_details_from_wallet_connector,
                 collect_shipping_details_from_wallet_connector: configParams.collect_shipping_details_from_wallet_connector,
                 platform: configParams.platform,
                 profile_id: ?configParams.profile_id,
                 processor_merchant_id: ?configParams.processor_merchant_id,
+                provider_merchant_id: ?configParams.provider_merchant_id,
                 organization_id: ?configParams.organization_id,
               }
               let resolvedConfig =

--- a/sdk-utils/types/SdkConfigTypes.res
+++ b/sdk-utils/types/SdkConfigTypes.res
@@ -28,7 +28,7 @@ type accountConfig = {profile: option<profile>}
 
 type contextUsed = {
   profile_id: option<string>,
-  merchant_id: option<string>,
+  processor_merchant_id: option<string>,
   organization_id: option<string>,
 }
 

--- a/sdk-utils/types/SdkConfigTypes.res
+++ b/sdk-utils/types/SdkConfigTypes.res
@@ -26,14 +26,22 @@ type profile = {
 
 type accountConfig = {profile: option<profile>}
 
+type contextUsed = {
+  profile_id: option<string>,
+  merchant_id: option<string>,
+  organization_id: option<string>,
+}
+
 type sdkConfigValue = {
   raw_configs: option<JSON.t>,
   payment_methods: array<sdkPaymentMethod>,
   account_config: option<accountConfig>,
+  context_used: option<contextUsed>,
 }
 
 let defaultSdkConfigValue: sdkConfigValue = {
   raw_configs: None,
   payment_methods: [],
   account_config: None,
+  context_used: None,
 }

--- a/sdk-utils/types/SuperpositionTypes.res
+++ b/sdk-utils/types/SuperpositionTypes.res
@@ -54,6 +54,9 @@ type superpositionBaseContext = {
   mandate_type: string,
   collect_shipping_details_from_wallet_connector: string,
   collect_billing_details_from_wallet_connector: string,
+  profile_id?: string,
+  merchant_id?: string,
+  organization_id?: string,
 }
 
 type superpositionContext = {

--- a/sdk-utils/types/SuperpositionTypes.res
+++ b/sdk-utils/types/SuperpositionTypes.res
@@ -55,7 +55,7 @@ type superpositionBaseContext = {
   collect_shipping_details_from_wallet_connector: string,
   collect_billing_details_from_wallet_connector: string,
   profile_id?: string,
-  merchant_id?: string,
+  processor_merchant_id?: string,
   organization_id?: string,
 }
 

--- a/sdk-utils/types/SuperpositionTypes.res
+++ b/sdk-utils/types/SuperpositionTypes.res
@@ -55,8 +55,10 @@ type superpositionBaseContext = {
   mandate_type: string,
   collect_shipping_details_from_wallet_connector: string,
   collect_billing_details_from_wallet_connector: string,
+  currency?: string,
   profile_id?: string,
   processor_merchant_id?: string,
+  provider_merchant_id?: string,
   organization_id?: string,
 }
 

--- a/sdk-utils/types/SuperpositionTypes.res
+++ b/sdk-utils/types/SuperpositionTypes.res
@@ -50,6 +50,7 @@ type requiredFields = array<fieldConfig>
 type superpositionBaseContext = {
   payment_method: string,
   payment_method_type: string,
+  platform: string,
   country: string,
   mandate_type: string,
   collect_shipping_details_from_wallet_connector: string,

--- a/sdk-utils/utils/SdkConfigParser.res
+++ b/sdk-utils/utils/SdkConfigParser.res
@@ -67,6 +67,15 @@ let parseProfileAccountConfig = (json: JSON.t): accountConfig => {
   }
 }
 
+let parseContextUsed = (json: JSON.t): contextUsed => {
+  let dict = json->getDictFromJson
+  {
+    profile_id: dict->getOptionString("profile_id"),
+    merchant_id: dict->getOptionString("merchant_id"),
+    organization_id: dict->getOptionString("organization_id"),
+  }
+}
+
 let getCollectBillingDetailsFromWalletConnector = (profile: option<profile>): bool => {
   switch profile {
   | None => true
@@ -91,6 +100,13 @@ let getCollectShippingDetailsFromWalletConnector = (profile: option<profile>): b
   }
 }
 
+let getProfileContext = (contextUsed: option<contextUsed>) => {
+  switch contextUsed {
+  | Some(context) => (context.profile_id, context.merchant_id, context.organization_id)
+  | None => (None, None, None)
+  }
+}
+
 let itemToObjMapper = (json: JSON.t): sdkConfigValue => {
   let dict = json->getDictFromJson
   {
@@ -99,6 +115,7 @@ let itemToObjMapper = (json: JSON.t): sdkConfigValue => {
     account_config: dict
     ->Dict.get("account_config")
     ->Option.map(parseProfileAccountConfig),
+    context_used: dict->Dict.get("context_used")->Option.map(parseContextUsed),
   }
 }
 

--- a/sdk-utils/utils/SdkConfigParser.res
+++ b/sdk-utils/utils/SdkConfigParser.res
@@ -71,7 +71,7 @@ let parseContextUsed = (json: JSON.t): contextUsed => {
   let dict = json->getDictFromJson
   {
     profile_id: dict->getOptionString("profile_id"),
-    merchant_id: dict->getOptionString("merchant_id"),
+    processor_merchant_id: dict->getOptionString("processor_merchant_id"),
     organization_id: dict->getOptionString("organization_id"),
   }
 }
@@ -102,7 +102,7 @@ let getCollectShippingDetailsFromWalletConnector = (profile: option<profile>): b
 
 let getProfileContext = (contextUsed: option<contextUsed>) => {
   switch contextUsed {
-  | Some(context) => (context.profile_id, context.merchant_id, context.organization_id)
+  | Some(context) => (context.profile_id, context.processor_merchant_id, context.organization_id)
   | None => (None, None, None)
   }
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD

## Description

- Added (missing) `currency`, `organization_id`, `profile_id`, `processor_merchant_id`, `provider_merchant_id`, `platform` as dimension for superposition's dynamicFields resolution.
- `organization_id`, `profile_id`, `processor_merchant_id` are received in `sdk-configs` api response.

- #### Current superposition dimensions.
<img width="1252" height="505" alt="image" src="https://github.com/user-attachments/assets/8ff1a07b-917f-4345-9c73-1124071acf1f" />
<img width="1252" height="271" alt="image" src="https://github.com/user-attachments/assets/c73b6566-8c54-4dc0-8e8d-589cbf4f9866" />

- **NOTE** : `merchant_id` dimension is to be deprecated, and isn't being used right now.


## How did you test it?
- Added override on superposition integ for a `profile_id`. Got the expected resolved config for `dynamicFields` on platform `web`.

- #### Superposition dashboard (Integ)
<img width="1375" height="577" alt="image" src="https://github.com/user-attachments/assets/f9e1d99e-603b-4cb1-bbed-9abd3d350128" />

- #### Web sdk 
<img width="612" height="807" alt="image" src="https://github.com/user-attachments/assets/b33d729a-326d-40be-850d-af7ac1dbf9a1" />

## Impact on Mobile and Web Repositories

Outline steps taken to ensure compatibility with consuming repositories:

- [X] I tested the submodule changes in the **mobile repository**.
- [X] I tested the submodule changes in the **web repository**.
- [ ] I updated the corresponding documentation in both repositories, if applicable.
- [X] I confirmed the changes do not introduce regressions in either repository.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I reviewed submitted code thoroughly.
- [X] I ensured the changes are compatible with **both mobile and web repositories**.
- [X] I communicated potential breaking changes, if any, to the relevant teams. @Pradeep-kumar1202 
