### PR TITLE
fix: remove shipping fields filter on requiredFields

### DIFF
--- a/sdk-utils/hooks/ConfigurationService.res
+++ b/sdk-utils/hooks/ConfigurationService.res
@@ -60,7 +60,7 @@ let useConfigurationService = (~rawConfigs: option<JSON.t>) => {
           }
           acc
         })
-        ->removeShippingAndDuplicateFields
+        ->removeDuplicateFields
         ->sortFieldsByPriorityOrder
       }
 

--- a/sdk-utils/utils/SuperpositionHelper.res
+++ b/sdk-utils/utils/SuperpositionHelper.res
@@ -19,14 +19,11 @@ let removeDuplicateConnectors = fields => {
   )
 }
 
-let removeShippingAndDuplicateFields = fields => {
+let removeDuplicateFields = fields => {
   let seen = Set.make()
 
   fields->Array.filter(f =>
-    if (
-      f.intentDataReadPath->Option.mapOr(false, s => s->String.startsWith("shipping.")) ||
-        Set.has(seen, f.confirmRequestWritePath)
-    ) {
+    if Set.has(seen, f.confirmRequestWritePath) {
       false
     } else {
       Set.add(seen, f.confirmRequestWritePath)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [X] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD

## Description
- removed `shippingFields` filter on dynamicFields array

## How did you test it?
- web sdk

## Impact on Mobile and Web Repositories

Outline steps taken to ensure compatibility with consuming repositories:

- [ ] I tested the submodule changes in the **mobile repository**. -- NON BREAKING CHANGE FOR MOBILE
- [X] I tested the submodule changes in the **web repository**.
- [ ] I updated the corresponding documentation in both repositories, if applicable.
- [ ] I confirmed the changes do not introduce regressions in either repository.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [X] I reviewed submitted code thoroughly.
- [X] I ensured the changes are compatible with **both mobile and web repositories**.
- [ ] I communicated potential breaking changes, if any, to the relevant teams.
