### PR TITLE
ref: optimized the payment_experience object

### DIFF
--- a/sdk-utils/utils/SdkConfigParser.res
+++ b/sdk-utils/utils/SdkConfigParser.res
@@ -141,23 +141,37 @@ let getEligibleConnectorsFromPaymentMethods = (
   })
 }
 
-let getPaymentExperienceFromPaymentMethods = (
+let paymentExperienceCriteria = "payment_experience"
+let defaultCriteriaValue = "default"
+
+let paymentMethodKey = (paymentMethod: string, paymentMethodType: string) =>
+  `${paymentMethod}:${paymentMethodType}`
+
+let buildPaymentExperienceIndex = (
   paymentMethods: array<sdkPaymentMethod>,
-  paymentMethod: string,
-  paymentMethodType: string,
-) => {
-  paymentMethods
-  ->Array.filter(pm => pm.payment_method === paymentMethod)
-  ->Array.flatMap(pm => pm.payment_method_types)
-  ->Array.filter(pmt =>
-    pmt.payment_method_type === paymentMethodType &&
-      pmt.payment_method_criteria === "payment_experience"
+): Dict.t<array<string>> => {
+  let index = Dict.make()
+  paymentMethods->Array.forEach(pm =>
+    pm.payment_method_types->Array.forEach(pmt =>
+      if pmt.payment_method_criteria === paymentExperienceCriteria {
+        let key = paymentMethodKey(pm.payment_method, pmt.payment_method_type)
+        let experiences = switch index->Dict.get(key) {
+        | Some(existing) => existing
+        | None =>
+          let created = []
+          index->Dict.set(key, created)
+          created
+        }
+        pmt.criteria_rules->Array.forEach(rule =>
+          if (
+            rule.criteria_value !== defaultCriteriaValue &&
+              !(experiences->Array.includes(rule.criteria_value))
+          ) {
+            experiences->Array.push(rule.criteria_value)
+          }
+        )
+      }
+    )
   )
-  ->Array.flatMap(pmt => pmt.criteria_rules)
-  ->Array.reduce([], (acc, rule) => {
-    if rule.criteria_value !== "default" && !(acc->Array.includes(rule.criteria_value)) {
-      acc->Array.push(rule.criteria_value)
-    }
-    acc
-  })
+  index
 }


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] CI/CD

## Description

**Before** :  Every time the SDK wanted the experiences for one payment method, it re-scanned the entire sdk-config list from scratch — filter the methods, flatten their sub-types, filter again, flatten the rules, then dedup. The one real caller does this inside the /client response parser.

**After** : The config is walked once, producing a dictionary from "payment_method:payment_method_type" to its experience list. Answering the question for a method becomes a single O(1) dictionary lookup. The scan cost is paid once per parsed sdk-config instead of once per payment method

<!-- Describe your changes in detail -->

- Doesn't effect web repo independent re-usable func
-  replace the per-lookup `sdk-config` scan with a build-once payment-experience index

## How did you test it?

<!--
Describe how you tested your changes:

- Did you write integration/unit/API tests?
- Did you verify compatibility with both the mobile and web repositories (provide steps)?
- Attach relevant logs or screenshots, if applicable.
-->

## Impact on Mobile and Web Repositories

Outline steps taken to ensure compatibility with consuming repositories:

- [x] I tested the submodule changes in the **mobile repository**.
- [ ] I tested the submodule changes in the **web repository**.
- [ ] I updated the corresponding documentation in both repositories, if applicable.
- [ ] I confirmed the changes do not introduce regressions in either repository.

## Checklist

<!-- Put an `x` in the boxes that apply -->

- [ ] I reviewed submitted code thoroughly.
- [ ] I ensured the changes are compatible with **both mobile and web repositories**.
- [ ] I communicated potential breaking changes, if any, to the relevant teams.
